### PR TITLE
use remaining args as the commit message

### DIFF
--- a/g.zsh
+++ b/g.zsh
@@ -454,7 +454,7 @@ function _git_commit_with_message()
 
   # Otherwise, just the argument
   else
-    _commit_message=$1
+    _commit_message=$*
   fi
   
   # Check for commit message


### PR DESCRIPTION
_git_commit_with_message(): use remaining args as the commit message instead of using the first arg only
